### PR TITLE
Add CFP button to the hero section

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -65,7 +65,7 @@ eventDate: "11/12 November 2016"
 typeoutTextValues: '"Karlsruhe?", "Hamburg?", "Vienna?", "Malta?", "Zurich?", "Brussels?", "Berlin 2016!"'
 typeoutFallback: "Berlin 2016"
 heroButtons:
-# - {permalink: "/schedule", text: "See the schedule"} 
+ - {permalink: "https://www.papercall.io/cfps/179/submissions/new", text: "Submit your talk or workshop"} 
 # - {permalink: "/#tickets", text: "Redeem ticket code"}
 
 # About Block


### PR DESCRIPTION
This changes the configuration to render a button on the main page on top of the hero image.

Currently one button will be displayed to invite more speakers to join the CFP. 

We can afford to add at least one more in a later PR.
