### PR TITLE
Remove submit talk button from home page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -64,8 +64,8 @@ heroTitle: "DevFest <typeout>"
 eventDate: "11/12 November 2016"
 typeoutTextValues: '"Karlsruhe?", "Hamburg?", "Vienna?", "Malta?", "Zurich?", "Brussels?", "Berlin 2016!"'
 typeoutFallback: "Berlin 2016"
-heroButtons:
- - {permalink: "https://www.papercall.io/cfps/179/submissions/new", text: "Submit your talk or workshop"} 
+# heroButtons:
+# - {permalink: "https://www.papercall.io/cfps/179/submissions/new", text: "Submit your talk or workshop"} 
 # - {permalink: "/#tickets", text: "Redeem ticket code"}
 
 # About Block


### PR DESCRIPTION
As discussed.
We closed the call for papers already, so we can remove the button from home page.
