### PR TITLE
Add Fireside chat details

### DIFF
--- a/_data/sessions.yml
+++ b/_data/sessions.yml
@@ -304,7 +304,7 @@
   id: 2013
   title: "Fireside chat"
   subtype: fireside
-  description: ""
+  description: "Open discussion with speakers and audience about the future of Android"
 
 #-
 #  id: 2013
@@ -443,7 +443,7 @@
   id: 2107
   title: "Fireside chat"
   subtype: fireside
-  description: ""
+  description: "Open discussion with speakers and audience about the future of Cloud Computing"
 
 
 ###############
@@ -552,4 +552,4 @@
   id: 2209
   title: "Fireside chat"
   subtype: fireside
-  description: ""
+  description: "Please attend the fireside chats at the Atrium (Android) or Casino (Cloud)."


### PR DESCRIPTION
Given we didn't really have a web track this year it doesn't make sense to have 3 fireside chats. The Casino is the better location for that setup so we won't do anything in Konfi 4+5 and people can join the discussion either in the Atrium (Android) or Casino (Cloud).